### PR TITLE
Ignore Jekyll cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ _site
 .Rproj.user
 .Rhistory
 .RData
-
+.jekyll-cache


### PR DESCRIPTION
When I run `make serve` to run Jekyll locally, it creates a cache directory that shows as untracked changes in git. This addition to .gitignore tells git to never include the Jekyll cache in commits.