### PR TITLE
Add note for Hannover slides about licenses

### DIFF
--- a/_episodes/05-reusable.md
+++ b/_episodes/05-reusable.md
@@ -112,3 +112,6 @@ Reference Management w/ Zotero or other
 demo: import Zenodo.org/record/1308061 into Zotero
 demo: RStudio > Packages > Update, run PANGAEA example, then install updates
 https://tibhannover.github.io/2018-07-09-FAIR-Data-and-Software/FAIR-remix-PANGAEA/index.html
+
+Useful content for Licenses
+Note: TIB Hannover Slides https://docs.google.com/presentation/d/1mSeanQqO0Y2khA8KK48wtQQ_JGYncGexjnspzs7cWLU/edit#slide=id.g3a64c782ff_1_138


### PR DESCRIPTION
Add note from the Licenses episode about the Hannover slides. This is in preparation for merging these two episodes.