### PR TITLE
Use DOIs for articles

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -38,7 +38,7 @@ The FAIR data principles are all about how machines and humans communicate with 
 
 ## Where did FAIR come from?
 
-The FAIR data principles emerged from a FORCE11 workshop in 2014. This was formalised in 2016 when these were published in Scientific Data: [FAIR Guiding Principles for scientific data management and stewardship](https://www.nature.com/articles/sdata201618). In this article, the authors provide general guidance on machine-actionability and improvements that can be made to streamline the findability, accessibility, interoperatbility, and reuability (FAIR) of digital assets.   
+The FAIR data principles emerged from a FORCE11 workshop in 2014. This was formalised in 2016 when these were published in Scientific Data: [FAIR Guiding Principles for scientific data management and stewardship](https://doi.org/10.1038/sdata.2016.18). In this article, the authors provide general guidance on machine-actionability and improvements that can be made to streamline the findability, accessibility, interoperatbility, and reuability (FAIR) of digital assets.   
 
 "as open as possible, as closed as necessary"
 

--- a/_episodes/05-reusable.md
+++ b/_episodes/05-reusable.md
@@ -52,7 +52,7 @@ For others to reuse your research, it is important to include a README file and 
 It is also good practice to include README files to describe how the data was collected, processed, and analyzed. In other words, README files help others correctly interpret and reanalyze your data. A README file can include file names/directory structure, glossary/definitions of acronyms/terms, description of the parameters/variables and units of measurement, report precision/accuracy/uncertainty in measurements, standards/calibrations used, environment/experimental conditions, quality assurance/quality control applied, known problems, research date information, description of relationships/dependencies, additional resources/references, methods/software/data used, example records, and other supplemental information. 
 
 Dryad README file example:
-https://datadryad.org//resource/doi:10.5061/dryad.j512f21p
+<https://doi.org/10.5061/dryad.j512f21p>
 
 Awesome README list (for software):
 https://github.com/matiassingers/awesome-readme

--- a/_episodes/08-software.md
+++ b/_episodes/08-software.md
@@ -21,6 +21,6 @@ The objective of this lesson is to get learners up to speed on accepted best pra
 ## Resources
 
 As starting points, we have the following resources: 
-- a position paper: https://content.iospress.com/articles/data-science/ds190026
+- a position paper: https://doi.org/10.3233/DS-190026
 - a FAIR Software guide, with 5 recommendations: https://fair-software.nl/ 
 


### PR DESCRIPTION
This fixes #11 (I think) and replaces article URLs with their DOIs. 

This does not prevent new links being added that should have been PIDs, so perhaps we should add a note somewhere for lesson contributors – maybe in the pull request template? Or even more strict: have an automatic check for links that look like they should have been PIDs.